### PR TITLE
Fix and expand Ironsworn combat example

### DIFF
--- a/docs/en/lonelog-combat-addon.md
+++ b/docs/en/lonelog-combat-addon.md
@@ -578,6 +578,10 @@ d: Action=3+Heart=2=5 vs Challenge=6,8 -> Miss
 @ Face Danger (Attempting to deflect the incoming strike)
 d: Action=1+Iron=3=4 vs Challenge=7,8 -> Miss
 => Pay the Price: -3 health. Foe retains initiative.
+
+@ Endure Harm (-3 health)
+d: Action=2+Iron=3=5 vs Challenge=4,8 -> Weak Hit
+=> Press on.
 [PC:Alex|health-3]
 
 @ Clash (foe has initiative, close quarters)

--- a/docs/en/lonelog-combat-addon.md
+++ b/docs/en/lonelog-combat-addon.md
@@ -568,18 +568,34 @@ These systems use move-based resolution without traditional initiative. Round ma
 
 ```
 [COMBAT]
-[F:Broken|Threat 3|Engaged]
+[F:Broken|Formidable|Engaged]
+[Track:Broken|Progress 0/10]
 
-@ Strike
-d: d6+3=8 vs d10=5, d10=3 -> Strong Hit
-=> +1 momentum. [F:Broken|Threat-2|Threat 1|staggered]
+@ Enter the Fray (facing off)
+d: Action=3+Heart=2=5 vs Challenge=6,8 -> Miss
+=> Broken strikes first. Pay the Price. Foe has initiative.
 
-@(Broken) Counters
-d: d10=7 -> Endure Harm
-d: d6+2=6 vs d10=8, d10=4 -> Weak Hit
-=> -1 health, press on.
-[PC:Alex|health-1]
+@ Face Danger (Attempting to deflect the incoming strike)
+d: Action=1+Iron=3=4 vs Challenge=7,8 -> Miss
+=> Pay the Price: -3 health. Foe retains initiative.
+[PC:Alex|health-3]
 
+@ Clash (foe has initiative, close quarters)
+d: Action=4+Iron=3=7 vs Challenge=5,9 -> Miss
+=> Momentum=10 > Challenge=5,9; burn to cancel both challenge dice -> Strong Hit
+=> +1 Harm. 3 harm (deadly weapon) -> mark 3 progress. I gain the initiative.
+[Track:Broken|Progress 3/10]
+[PC:Alex|momentum=2]
+
+@ Strike (I have initiative, close quarters)
+d: Action=6+Iron=3=9 vs Challenge=2,4 -> Strong Hit
+=> +1 harm. 3 harm (deadly weapon) -> mark 3 progress. I retain initiative.
+[Track:Broken|Progress 6/10]
+
+@ End the Fight
+d: Progress=6 vs Challenge=3,5 -> Strong Hit
+=> Broken is no longer in the fight.
+[F:Broken|dead]
 [/COMBAT]
 ```
 


### PR DESCRIPTION
I had two fundamental issues with the existing combat examples:

1. The Threat level, which is not a term used in Ironsworn, and
2. The inconsistencies between the core Lonelog notation and what is used in this Combat add-on

What do I mean by inconsistencies? Well, in core Lonelog notation we had this:

d: Action=4+Stat=2=6 vs Challenge=4,8 -> Weak Hit
d: Action=6+Stat=3=9 vs Challenge=2,7 -> Strong Hit

That is, explicitly named Action dice and named Stat addition on top of that. This was very clearly formatted. Now compare it to what the Combat add-on has:

@ Strike
d: d6+3=8 vs d10=5, d10=3 -> Strong Hit
=> +1 momentum. [F:Broken|Threat-2|Threat 1|staggered]

While yes, the Action dice is a d6 and the challenge dice are d10, why not call them the same thing throughout the notation? Also, what is the +3? What stat was used here? You wouldn't know without checking the character sheet if you don't remember it by heart. Again, it was explicitly mentioned elsewhere in rolls, why not continue here?

As for the foes, Ironsworn does not have anything that says "Threat level". Ironsworn uses Ranks: Troublesome, Dangerous, Formidable, Extreme and Epic. So this should be used as tag for the Foe, because it's also used in the calculation for how much progress each inflicted Harm makes. So, we need to keep progress of how many boxes we've already filled, hence the foe gets a progress track. Also note that the Rank determines how much Harm the foe inflicts (1-5 respectively), so it's worth mentioning here.

The example also lacked the initiative rules, which I hope the provided examples expand adequately on. I also added Momentum Burning into the mix for good measure, although this could be a candidate for a core notation example in a future update.